### PR TITLE
adjustments for readonly filesystems

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -19,6 +19,7 @@ import sys
 import glob
 import json
 import copy
+import tempfile
 
 from encodings import hex_codec  # explicit for pyinstaller
 from encodings import ascii  # explicit for pyinstaller
@@ -36,6 +37,7 @@ conf = {
     'baudrate': 57600,
     'rootdir': None,                    # defined further down (../)
     'confdir': None,                    # defined further down
+    'stordir': None,                    # defined further down
     'hardware': None,                   # defined further down
     'firmware': None,                   # defined further down
     'tolerance': 0.01,
@@ -123,6 +125,12 @@ else:
 
 ### stordir
 # This is to be used to store queue files and similar
+conf['stordir'] = tempfile.mkdtemp('driveboardapp')
+#
+###
+
+### confdir
+# This is to be used to store the configuration file
 if sys.platform == 'darwin':
     directory = os.path.join(os.path.expanduser('~'),
                              'Library', 'Application Support',

--- a/backend/config.py
+++ b/backend/config.py
@@ -19,7 +19,6 @@ import sys
 import glob
 import json
 import copy
-import tempfile
 
 from encodings import hex_codec  # explicit for pyinstaller
 from encodings import ascii  # explicit for pyinstaller
@@ -124,7 +123,18 @@ else:
 
 ### stordir
 # This is to be used to store queue files and similar
-conf['confdir'] = tempfile.mkdtemp('driveboardapp')
+if sys.platform == 'darwin':
+    directory = os.path.join(os.path.expanduser('~'),
+                             'Library', 'Application Support',
+                             conf['company_name'], conf['appname'])
+elif sys.platform == 'win32':
+    directory = os.path.join(os.path.expandvars('%APPDATA%'),
+                             conf['company_name'], conf['appname'])
+else:
+    directory = os.path.join(os.path.expanduser('~'), "." + conf['appname'])
+if not os.path.exists(directory):
+    os.makedirs(directory)
+conf['confdir'] = directory
 #
 ###
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -19,6 +19,7 @@ import sys
 import glob
 import json
 import copy
+import tempfile
 
 from encodings import hex_codec  # explicit for pyinstaller
 from encodings import ascii  # explicit for pyinstaller
@@ -123,18 +124,7 @@ else:
 
 ### stordir
 # This is to be used to store queue files and similar
-if sys.platform == 'darwin':
-    directory = os.path.join(os.path.expanduser('~'),
-                             'Library', 'Application Support',
-                             conf['company_name'], conf['appname'])
-elif sys.platform == 'win32':
-    directory = os.path.join(os.path.expandvars('%APPDATA%'),
-                             conf['company_name'], conf['appname'])
-else:
-    directory = os.path.join(os.path.expanduser('~'), "." + conf['appname'])
-if not os.path.exists(directory):
-    os.makedirs(directory)
-conf['confdir'] = directory
+conf['confdir'] = tempfile.mkdtemp('driveboardapp')
 #
 ###
 

--- a/backend/driveboard.py
+++ b/backend/driveboard.py
@@ -1536,7 +1536,10 @@ def disable_computer_sleep():
     elif system == 'Linux':
         import subprocess
         args = ['sleep.target', 'suspend.target', 'hibernate.target', 'hybrid-sleep.target']
-        subprocess.run(['systemctl', 'mask', *args])
+        try:
+            subprocess.run(['systemctl', 'mask', *args])
+        except:
+            print('Failed to disable hibernation')
     else: # if system == 'Darwin':
         print(f'Display disabling not implemented in {system}')
 
@@ -1548,7 +1551,10 @@ def enable_computer_sleep():
     elif system == 'Linux':
         import subprocess
         args = ['sleep.target', 'suspend.target', 'hibernate.target', 'hybrid-sleep.target']
-        subprocess.run(['systemctl', 'unmask', *args])
+        try:
+            subprocess.run(['systemctl', 'unmask', *args])
+        except:
+            print('Failed to reenable hibernation')
     else: # if system == 'Darwin':
         print(f'Display disabling not implemented in {system}')
 

--- a/backend/web.py
+++ b/backend/web.py
@@ -360,7 +360,7 @@ def _get_sorted(globpattern, library=False, stripext=False):
             files = list(filter(os.path.isfile, glob.glob(globpattern)))
             files.sort()
         else:
-            os.chdir(conf['confdir'])
+            os.chdir(conf['stordir'])
             files = list(filter(os.path.isfile, glob.glob(globpattern)))
             files.sort(key=lambda x: os.path.getmtime(x))
         if stripext:
@@ -378,7 +378,7 @@ def _get(jobname, library=False):
     if library:
         jobpath = os.path.join(conf['rootdir'], 'library', jobname.strip('/\\'))
     else:
-        jobpath = os.path.join(conf['confdir'], jobname.strip('/\\'))
+        jobpath = os.path.join(conf['stordir'], jobname.strip('/\\'))
     if os.path.exists(jobpath+'.dba'):
         jobpath = jobpath+'.dba'
     elif os.path.exists(jobpath + '.dba.starred'):
@@ -393,7 +393,7 @@ def _get_path(jobname, library=False):
     if library:
         jobpath = os.path.join(conf['rootdir'], 'library', jobname.strip('/\\'))
     else:
-        jobpath = os.path.join(conf['confdir'], jobname.strip('/\\'))
+        jobpath = os.path.join(conf['stordir'], jobname.strip('/\\'))
     if os.path.exists(jobpath+'.dba'):
         return jobpath+'.dba'
     elif os.path.exists(jobpath+'.dba.starred'):
@@ -402,7 +402,7 @@ def _get_path(jobname, library=False):
         bottle.abort(400, "No such file.")
 
 def _exists(jobname):
-    namepath = os.path.join(conf['confdir'], jobname.strip('/\\'))
+    namepath = os.path.join(conf['stordir'], jobname.strip('/\\'))
     if os.path.exists(namepath+'.dba') or os.path.exists(namepath+'.dba.starred'):
         bottle.abort(400, "File name exists.")
 
@@ -413,7 +413,7 @@ def _clear(limit=None):
     for filename in files:
         if type(limit) is int and limit <= 0:
             break
-        filename = os.path.join(conf['confdir'], filename)
+        filename = os.path.join(conf['stordir'], filename)
         os.remove(filename);
         print("file deleted: " + filename)
         if type(limit) is int:
@@ -422,7 +422,7 @@ def _clear(limit=None):
 def _add(job, name):
     # add job (dba string)
     # overwrites file if already exists, use _unique_name(name) to avoid
-    namepath = os.path.join(conf['confdir'], name.strip('/\\')+'.dba')
+    namepath = os.path.join(conf['stordir'], name.strip('/\\')+'.dba')
     with open(namepath, 'w') as fp:
         fp.write(job)
         print("file saved: " + namepath)
@@ -812,6 +812,7 @@ def start(browser=False, debug=False):
         bottle.debug(True)
     print("Library Directory: " + conf['rootdir'])
     print("Config Directory: " + conf['confdir'])
+    print("Queue Directory: " + conf['stordir'])
     print("-----------------------------------------------------------------------------")
     print("Starting server at http://%s:%d/" % ('127.0.0.1', conf['network_port']))
     print("-----------------------------------------------------------------------------")


### PR DESCRIPTION
When running the driveboard app on something like a Raspberry Pi, from an SD card, it is desirable to use a read only filesystem to prolong the life of the SD card. These changes are mostly with Linux in mind.

- On a read-only filesystem, `mask`-ing or `unmask`-ing with systemd is not possible because you would have to write the symlinks to the files.
- Temporary directories on Linux are usually handled by an in-memory filesystem so are not affected by the read-only attribute of the root filesystem.