### PR TITLE
Option to require units in SVG files

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -69,6 +69,7 @@ conf = {
     'mill_max_rpm': 18000,
     'alignment_host': None,
     'alignment_port': 80,
+    'require_unit': False,
 }
 conf_defaults = copy.deepcopy(conf)
 
@@ -101,6 +102,7 @@ userconfigurable = {
     'mill_max_rpm': "Maximum spindle RPM.",
     'alignment_host': "IP or hostname of alignment server.",
     'alignment_port': "Port of alignment server.",
+    'require_unit': "Whether a physical unit (cm, mm, in) should be required to load SVG files.",
 }
 
 

--- a/backend/jobimport/__init__.py
+++ b/backend/jobimport/__init__.py
@@ -53,8 +53,7 @@ def convert(job, optimize=True, tolerance=conf['tolerance'], matrix=None):
                     job['head'] = {}
                 job['head']['optimized'] = tolerance
     elif type_ == 'svg':
-        job = read_svg(job, conf['workspace'],
-                       tolerance, optimize=optimize)
+        job = read_svg(job, tolerance, optimize=optimize)
     elif type_ == 'dxf':
         job = read_dxf(job, tolerance, optimize=optimize)
     elif type_ == 'gcode':
@@ -88,9 +87,9 @@ def apply_alignment_matrix(job, matrix):
                     matrixApply(mat, one_point)
 
 
-def read_svg(svg_string, workspace, tolerance, forced_dpi=None, optimize=True):
+def read_svg(svg_string, tolerance, forced_dpi=None, optimize=True):
     """Read a svg file string and convert to dba job."""
-    svgReader = SVGReader(tolerance, workspace)
+    svgReader = SVGReader(tolerance, conf['workspace'])
     res = svgReader.parse(svg_string, forced_dpi, conf['require_unit'])
     # {'boundarys':b, 'dpi':d, 'lasertags':l, 'rasters':r}
 

--- a/backend/jobimport/__init__.py
+++ b/backend/jobimport/__init__.py
@@ -91,7 +91,7 @@ def apply_alignment_matrix(job, matrix):
 def read_svg(svg_string, workspace, tolerance, forced_dpi=None, optimize=True):
     """Read a svg file string and convert to dba job."""
     svgReader = SVGReader(tolerance, workspace)
-    res = svgReader.parse(svg_string, forced_dpi)
+    res = svgReader.parse(svg_string, forced_dpi, conf['require_unit'])
     # {'boundarys':b, 'dpi':d, 'lasertags':l, 'rasters':r}
 
     # create an dba job from res

--- a/backend/jobimport/svg_reader.py
+++ b/backend/jobimport/svg_reader.py
@@ -102,7 +102,7 @@ class SVGReader:
 
 
 
-    def parse(self, svgstring, force_dpi=None):
+    def parse(self, svgstring, force_dpi=None, require_unit=False):
         """ Parse a SVG document.
 
         This traverses through the document tree and collects all path
@@ -216,6 +216,8 @@ class SVGReader:
                     # prime for cm to mm conversion
                     self.px2mm *= 10.0
                     log.info("px2mm by svg cm unit")
+                elif require_unit:
+                    raise ValueError("Invalid or no unit in SVG data, must be 'mm', 'cm' or 'in'.")
                 elif unit == 'px' or unit == '':
                     # no physical units in file
                     # we have to interpret user (px) units

--- a/backend/web.py
+++ b/backend/web.py
@@ -488,6 +488,8 @@ def load():
     except TypeError:
         if DEBUG: traceback.print_exc()
         bottle.abort(400, "Invalid file type.")
+    except ValueError as e:
+        bottle.abort(422, str(e))
 
     if not overwrite:
         name = _unique_name(name)

--- a/frontend/controls.js
+++ b/frontend/controls.js
@@ -34,7 +34,7 @@ function controls_ready() {
       //   },
       //   error: function (data) {
       //     $().uxmessage('error', "/temp error.")
-      //     $().uxmessage('error', JSON.stringify(data), false)
+      //     $().uxmessage('error', data.responseText, false)
       //   }
       // })
       // $('#hamburger').dropdown("toggle")
@@ -181,7 +181,7 @@ function controls_ready() {
       },
       error: function (data) {
         $().uxmessage('error', "/load error.")
-        $().uxmessage('error', JSON.stringify(data), false)
+        $().uxmessage('error', data.responseText, false)
         app_run_btn.stop()
       },
       complete: function (data) {

--- a/frontend/import.js
+++ b/frontend/import.js
@@ -102,7 +102,7 @@ $(document).ready(function(){
       },
       error: function (data) {
         $().uxmessage('error', "/load error.")
-        $().uxmessage('error', JSON.stringify(data), false)
+        $().uxmessage('error', data.responseText, false)
       },
       complete: function (data) {
         $('#open_btn').button('reset')
@@ -125,7 +125,7 @@ $(document).ready(function(){
       url:'http://' + app_config_main.alignment_host + ':' + app_config_main.alignment_port + '/align/' + encodeURI(window.location.hostname) + '/' + window.location.port,
       error: function (data) {
         $().uxmessage('error', "/align error.")
-        $().uxmessage('error', JSON.stringify(data), false)
+        $().uxmessage('error', data.responseText, false)
       },
       complete: function (data) {
         $('#open_align_btn').button('reset')
@@ -143,7 +143,7 @@ $(document).ready(function(){
           },
           error: function (data) {
             $().uxmessage('error', "/load error.")
-            $().uxmessage('error', JSON.stringify(data), false)
+            $().uxmessage('error', data.responseText, false)
           }
         })
       }
@@ -172,7 +172,7 @@ function import_open(jobname, from_library) {
         jobhandler.render()
         jobhandler.draw()
       }
-      
+
       jobhandler.set(job, jobname, true, jobhandler_done)
 
       // debug, show image, stats
@@ -192,7 +192,7 @@ function import_open(jobname, from_library) {
     },
     error: function (data) {
       $().uxmessage('error', "/get error.")
-      $().uxmessage('error', JSON.stringify(data), false)
+      $().uxmessage('error', data.responseText, false)
     }
   })
 }

--- a/frontend/request.js
+++ b/frontend/request.js
@@ -16,9 +16,7 @@ function request_get(args) {
       400: function(s) {
         // alert(JSON.stringify(s))
         if ('responseText' in s) {
-          r = s.responseText;
-          var error_txt = r.slice(r.indexOf('<pre>')+5,r.lastIndexOf('</pre>'))
-          $().uxmessage('error', error_txt)
+          $().uxmessage('error', s.responseText)
         }
       },
       401: function() {
@@ -75,9 +73,7 @@ function request_post(args) {
       400: function(s) {
         // alert(JSON.stringify(s))
         if ('responseText' in s) {
-          r = s.responseText;
-          var error_txt = r.slice(r.indexOf('<pre>')+5,r.lastIndexOf('</pre>'))
-          $().uxmessage('error', error_txt)
+          $().uxmessage('error', s.responseText)
         }
       },
       401: function() {


### PR DESCRIPTION
In our Fablab we often get SVG files from guests or the guests use the Lasercutter themselves. There are often issues with incorrect scaling, which in turn is often caused by the driveboard app guessing the resolution of the file when no physical unit is specified. Instead of guessing the resolution, this introduces an option to disable the guessing and return an error message instead, which I think is a more up front and safer option.

The error rendering in the frontend is also improved: Instead of embedding a HTML page and/or showing some JSON, only the actual error message will be displayed.