### PR TITLE
fixup! validate jobs before running

### DIFF
--- a/backend/driveboard.py
+++ b/backend/driveboard.py
@@ -1122,6 +1122,7 @@ def job_laser_validate(jobdict):
                 check_point(pos, passidx, kind)
 
                 # add pos + size to get bottom right
+                pos = pos.copy()
                 size = def_["size"]
                 pos[0] += size[0]
                 pos[1] += size[1]


### PR DESCRIPTION
The code previously accidentally modified the position of all images and effectively moved them to the bottom right by their width and height. Instead, the coordinate checking for the bottom right corner of images should be performed on a copy of the coordinate array.